### PR TITLE
Integrate exAgentica into bio site

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,10 @@
           <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
           GitHub
         </a>
+        <a href="https://exagentica.ai" class="social-btn" target="_blank" rel="noopener noreferrer">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a4 4 0 0 1 4 4c0 2.2-1.8 4-4 4s-4-1.8-4-4a4 4 0 0 1 4-4z"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/><path d="M2 10c0-2.2 1.8-4 4-4"/><path d="M22 10c0-2.2-1.8-4-4-4"/><path d="M1 18c0-3 2-5 5-6"/><path d="M23 18c0-3-2-5-5-6"/></svg>
+          exAgentica
+        </a>
       </div>
     </div>
     <div class="hero-scroll">
@@ -123,7 +127,7 @@
           <p class="lead">John Engates builds AI agent systems that coordinate multiple autonomous agents to solve problems single agents can't. Over 30 years he's co-founded one of Texas's first ISPs, built hosting infrastructure for early YouTube, and created the distributed storage system that would become OpenStack Swift.</p>
           <p>At Rackspace (CTO, 2000-2018), his team built and managed the infrastructure that kept YouTube running as it grew from startup to billion-user platform acquired by Google. His team scaled "Fanatical Support," 24/7 expert help that became the company's identity. The Intensive Hosting division he ran supported some of the web's most demanding workloads when "the cloud" meant actual servers in actual data centers.</p>
           <p>In 2009, when a Facebook hardware engineering leader asked about open-sourcing data center hardware, John committed Rackspace as a founding member of the Open Compute Project. That same year, his team built the distributed storage system that would become OpenStack Swift. It now runs at CERN, Wikimedia, and hundreds of deployments worldwide.</p>
-          <p>The White House called in 2013 when Healthcare.gov's launch crisis needed infrastructure expertise. He sat in the Situation Room with heads of HHS and CMS, explaining what went wrong. At Cloudflare (Field CTO, 2021-2025), he guided enterprise AI and security deployments. Today he serves on the boards of Frost Bank (NYSE: CFR) and James Avery Artisan Jewelry, mentors Techstars companies, and leads <a href="https://chapter.simnet.org/sanantonio/home" target="_blank" rel="noopener noreferrer">SIM San Antonio</a>.</p>
+          <p>The White House called in 2013 when Healthcare.gov's launch crisis needed infrastructure expertise. He sat in the Situation Room with heads of HHS and CMS, explaining what went wrong. At Cloudflare (Field CTO, 2021-2025), he guided enterprise AI and security deployments. Today he builds multi-agent AI systems at <a href="https://exagentica.ai" target="_blank" rel="noopener noreferrer">exAgentica</a>, serves on the boards of Frost Bank (NYSE: CFR) and James Avery Artisan Jewelry, mentors Techstars companies, and leads <a href="https://chapter.simnet.org/sanantonio/home" target="_blank" rel="noopener noreferrer">SIM San Antonio</a>.</p>
           <div class="stats">
             <div class="stat">
               <span class="stat-number">30+</span>
@@ -396,6 +400,10 @@
           <a href="https://github.com/JohnEngates" target="_blank" rel="noopener noreferrer" class="contact-link">
             <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
             GitHub
+          </a>
+          <a href="https://exagentica.ai" target="_blank" rel="noopener noreferrer" class="contact-link">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a4 4 0 0 1 4 4c0 2.2-1.8 4-4 4s-4-1.8-4-4a4 4 0 0 1 4-4z"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/><path d="M2 10c0-2.2 1.8-4 4-4"/><path d="M22 10c0-2.2-1.8-4-4-4"/><path d="M1 18c0-3 2-5 5-6"/><path d="M23 18c0-3-2-5-5-6"/></svg>
+            exAgentica
           </a>
         </div>
         <div class="contact-actions">


### PR DESCRIPTION
Integrates exagentica.ai more prominently throughout the bio site.

**Changes:**
- Add exAgentica social button in hero section
- Update About section to explicitly name exAgentica with link
- Add exAgentica to contact links section

Closes #9

Generated with [Claude Code](https://claude.ai/code)